### PR TITLE
UPGRADE - bring playwright to v1.33.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "devDependencies": {
         "@axe-core/playwright": "^4.6.1",
-        "@playwright/test": "^1.32.1",
+        "@playwright/test": "^1.33.0",
         "colors": "^1.4.0",
         "dotenv": "^16.0.3",
         "prettier": "^2.8.7",
@@ -50,13 +50,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.32.3",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.32.3.tgz",
-      "integrity": "sha512-BvWNvK0RfBriindxhLVabi8BRe3X0J9EVjKlcmhxjg4giWBD/xleLcg2dz7Tx0agu28rczjNIPQWznwzDwVsZQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.33.0.tgz",
+      "integrity": "sha512-YunBa2mE7Hq4CfPkGzQRK916a4tuZoVx/EpLjeWlTVOnD4S2+fdaQZE0LJkbfhN5FTSKNLdcl7MoT5XB37bTkg==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
-        "playwright-core": "1.32.3"
+        "playwright-core": "1.33.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -66,6 +66,18 @@
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/@playwright/test/node_modules/playwright-core": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.33.0.tgz",
+      "integrity": "sha512-aizyPE1Cj62vAECdph1iaMILpT0WUDCq3E6rW6I+dleSbBoGbktvJtzS6VHkZ4DKNEOG9qJpiom/ZxO+S15LAw==",
+      "dev": true,
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@types/node": {
@@ -271,6 +283,7 @@
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.32.3.tgz",
       "integrity": "sha512-SB+cdrnu74ZIn5Ogh/8278ngEh9NEEV0vR4sJFmK04h2iZpybfbqBY0bX6+BLYWVdV12JLLI+JEFtSnYgR+mWg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "playwright": "cli.js"
       },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "devDependencies": {
     "@axe-core/playwright": "^4.6.1",
-    "@playwright/test": "^1.32.1",
+    "@playwright/test": "^1.33.0",
     "colors": "^1.4.0",
     "dotenv": "^16.0.3",
     "prettier": "^2.8.7",


### PR DESCRIPTION
upgrade playwright to [version 1.33.0](https://github.com/microsoft/playwright/releases/tag/v1.33.0) with the browser versions:

> Chromium 113.0.5672.53
> Mozilla Firefox 112.0
> WebKit 16.4